### PR TITLE
Check for RACK_ENV when pulling api key files

### DIFF
--- a/lib/spark_api/configuration/yaml.rb
+++ b/lib/spark_api/configuration/yaml.rb
@@ -31,13 +31,15 @@ module SparkApi
         @name
       end
       def api_env
-        current_env = "development"
-        if env.include?("SPARK_API_ENV")
-          current_env = env["SPARK_API_ENV"]
-        elsif env.include?("RAILS_ENV")
-          current_env = env["RAILS_ENV"]
+        if env.include? "SPARK_API_ENV"
+          env["SPARK_API_ENV"]
+        elsif env.include? "RAILS_ENV"
+          env["RAILS_ENV"]
+        elsif env.include? "RACK_ENV"
+          env["RACK_ENV"]
+        else
+          "development"
         end
-        return current_env
       end
       
       # Used to specify the root of where to look for SparkApi config files


### PR DESCRIPTION
For some reason thin doesn't seem to set RAILS_ENV, and sets RACK_ENV instead. I know places like Heroku use thin (it's not just me!) so hopefully this will fix those cases as well.
