### PR TITLE
MOBILE-410: increase OAuthSession default refresh timeout

### DIFF
--- a/lib/spark_api/authentication/oauth2.rb
+++ b/lib/spark_api/authentication/oauth2.rb
@@ -159,7 +159,7 @@ module SparkApi
         @scope = options["scope"]
         @refresh_token = options["refresh_token"]
         @start_time = options.fetch("start_time", DateTime.now)
-        @refresh_timeout = options.fetch("refresh_timeout",3600)
+        @refresh_timeout = options.fetch("refresh_timeout", 43200)
         if @start_time.is_a? String
           @start_time = DateTime.parse(@start_time)
         end

--- a/spec/oauth2_helper.rb
+++ b/spec/oauth2_helper.rb
@@ -25,7 +25,7 @@ class TestOAuth2Provider < SparkApi::Authentication::BaseOAuth2Provider
     nil
   end
   
-  def session_timeout; 7200; end
+  def session_timeout; 57600; end
   
 end
 

--- a/spec/unit/spark_api/authentication/oauth2_spec.rb
+++ b/spec/unit/spark_api/authentication/oauth2_spec.rb
@@ -23,7 +23,7 @@ describe SparkApi::Authentication::OAuth2  do
         ).
         to_return(:body => fixture("oauth2/access.json"), :status=>200)
       subject.authenticate.access_token.should eq("04u7h-4cc355-70k3n")
-      subject.authenticate.expires_in.should eq(7200)
+      subject.authenticate.expires_in.should eq(57600)
     end
     
     it "should raise an error when api credentials are invalid" do
@@ -246,7 +246,7 @@ describe SparkApi::Authentication::BaseOAuth2Provider  do
     describe TestOAuth2Provider do
       subject { TestOAuth2Provider.new }
       it "should be able to override the session timeout" do
-        subject.session_timeout.should eq(7200)
+        subject.session_timeout.should eq(57600)
       end
     end
   end


### PR DESCRIPTION
bumped up the default refresh timeout from 1 hour to 12 hours. I'm hoping this is the right spot. It will help decrease the frequency of the ajax redirects we've been getting in some of our more client heavy apps.
