### PR TITLE
MOBILE-621: ensure specified ApiUser doesnt get overwritten while reques...

### DIFF
--- a/lib/spark_api/authentication/api_auth.rb
+++ b/lib/spark_api/authentication/api_auth.rb
@@ -66,9 +66,11 @@ module SparkApi
         request_opts = {
           :AuthToken => @session.auth_token
         }
-        unless @client.api_user.nil?
+
+        unless (@client.api_user.nil? || options[:ApiUser])
           request_opts.merge!(:ApiUser => "#{@client.api_user}")
         end
+
         request_opts.merge!(options)
         sig = sign_token(escaped_path, request_opts, body)
         request_path = "#{escaped_path}?#{build_url_parameters({"ApiSig"=>sig}.merge(request_opts))}"

--- a/lib/spark_api/authentication/oauth2.rb
+++ b/lib/spark_api/authentication/oauth2.rb
@@ -43,7 +43,11 @@ module SparkApi
         escaped_path = URI.escape(path)
         connection = @client.connection(true)  # SSL Only!
         connection.headers.merge!(self.auth_header)
-        options.merge!(:ApiUser => "#{@client.api_user}") unless @client.api_user.nil?
+
+        unless (@client.api_user.nil? || options[:ApiUser])
+          options.merge!(:ApiUser => "#{@client.api_user}")
+        end
+
         parameter_string = options.size > 0 ? "?#{build_url_parameters(options)}" : ""
         request_path = "#{escaped_path}#{parameter_string}"
         SparkApi.logger.debug("Request: #{request_path}")


### PR DESCRIPTION
...t is made

When making requests similar to "@contact.save(:ApiUser => @recipient)", the specified ApiUser was being overwritten with the @client.api_user.
