### PR TITLE
 Reduce memory usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec :development_group => :test
 
 platforms :ruby do
-  gem 'yajl-ruby'
+  gem 'oj'
 end
 
 platforms :jruby do

--- a/lib/spark_api/configuration.rb
+++ b/lib/spark_api/configuration.rb
@@ -2,8 +2,8 @@ module SparkApi
   module Configuration
 
     begin
-      require 'yajl'
-      MultiJson.engine = "yajl"
+      require 'oj'
+      MultiJson.engine = :oj
     rescue LoadError => e
       # Using pure ruby JSON parser
     end

--- a/lib/spark_api/faraday_middleware.rb
+++ b/lib/spark_api/faraday_middleware.rb
@@ -61,7 +61,7 @@ module SparkApi
         raise ClientError, {:message => response.message, :code => response.code, :status => env[:status]}
       when 200..299
         SparkApi.logger.debug { "Success!" }
-      else 
+      else
         raise ClientError, {:message => response.message, :code => response.code, :status => env[:status]}
       end
       env[:body] = results

--- a/lib/spark_api/models/base.rb
+++ b/lib/spark_api/models/base.rb
@@ -9,10 +9,14 @@ module SparkApi
 
       attr_accessor :attributes, :errors, :parent
 
+      ID_KEY = 'Id'
+      RESOURCE_URI_KEY = 'ResourceUri'
+      TYPE_KEY = 'Type'
+
       # Name of the resource as related to the path name
       def self.element_name
         # TODO I'd love to pull in active model at this point to provide default naming
-        @element_name ||= "resource"
+        @element_name ||= 'resource'
       end
       def self.element_name=(name)
         @element_name = name
@@ -20,14 +24,14 @@ module SparkApi
 
       # Resource path prefix, prepended to the url
       def self.prefix
-        @prefix ||= "/"
+        @prefix ||= '/'
       end
       def self.prefix=(prefix)
         @prefix = prefix
       end
 
       def resource_uri
-        self.ResourceUri.sub(/^\/#{SparkApi.client.version}/, "") if persisted?
+        self.ResourceUri.sub(/^\/#{SparkApi.client.version}/, '') if persisted?
       end
 
       def self.path
@@ -122,10 +126,14 @@ module SparkApi
       end
 
       def persisted?;
-        !@attributes['Id'].nil? && !@attributes['ResourceUri'].nil?
+        !@attributes[ID_KEY].nil? && !@attributes[RESOURCE_URI_KEY].nil?
       end
 
       protected
+
+      def resource_type
+        attributes[TYPE_KEY]
+      end
 
       def write_attribute(attribute, value)
         attribute = attribute.to_s

--- a/lib/spark_api/models/video.rb
+++ b/lib/spark_api/models/video.rb
@@ -5,11 +5,11 @@ module SparkApi
       self.element_name = 'videos'
 
       def branded?
-        attributes['Type'] == 'branded'
+        resource_type == 'branded'
       end
 
       def unbranded?
-        attributes['Type'] == 'unbranded'
+        resource_type == 'unbranded'
       end
     end
   end

--- a/lib/spark_api/models/virtual_tour.rb
+++ b/lib/spark_api/models/virtual_tour.rb
@@ -2,15 +2,15 @@ module SparkApi
   module Models
     class VirtualTour < Base
       extend Subresource
-      self.element_name="virtualtours"
-      
+      self.element_name = 'virtualtours'
 
-      def branded? 
-        attributes["Type"] == "branded"
+
+      def branded?
+        resource_type == 'branded'
       end
 
       def unbranded?
-        attributes["Type"] == "unbranded"
+        resource_type == 'unbranded'
       end
 
     end

--- a/lib/spark_api/response.rb
+++ b/lib/spark_api/response.rb
@@ -7,22 +7,30 @@ module SparkApi
       @success
     end
   end
-  
+
   # Nice and handy class wrapper for the api response hash
   class ApiResponse < ::Array
     include SparkApi::Response
+    ROOT_KEY       = 'D'
+    MESSAGE_KEY    = 'Message'
+    CODE_KEY       = 'Code'
+    RESULTS_KEY    = 'Results'
+    SUCCESS_KEY    = 'Success'
+    PAGINATION_KEY = 'Pagination'
+    DETAILS_KEY    = 'Details'
+
     def initialize(d)
       begin
-        hash = d["D"]
+        hash = d[ROOT_KEY]
         if hash.nil? || hash.empty?
-          raise InvalidResponse, "The server response could not be understood"
+          raise InvalidResponse, 'The server response could not be understood'
         end
-        self.message    = hash["Message"]
-        self.code       = hash["Code"]
-        self.results    = Array(hash["Results"])
-        self.success    = hash["Success"]
-        self.pagination = hash["Pagination"]
-        self.details    = hash["Details"] || []
+        self.message    = hash[MESSAGE_KEY]
+        self.code       = hash[CODE_KEY]
+        self.results    = Array(hash[RESULTS_KEY])
+        self.success    = hash[SUCCESS_KEY]
+        self.pagination = hash[PAGINATION_KEY]
+        self.details    = hash[DETAILS_KEY] || []
         super(results)
       rescue Exception => e
         SparkApi.logger.error "Unable to understand the response! #{d}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,16 @@ FileUtils.mkdir 'log' unless File.exists? 'log'
 
 module SparkApi
   def self.logger
-    if @logger.nil?
-      @logger = Logger.new('log/test.log')
-      @logger.level = Logger::DEBUG
+    @logger ||= begin
+      if ENV['DEBUG']
+        FileUtils.mkdir 'log' unless File.exists? 'log'
+        Logger.new('log/test.log')
+      else
+        logger       = Logger.new(STDOUT)
+        logger.level = Logger::FATAL
+        logger
+      end
     end
-    @logger
   end
 end
 
@@ -35,7 +40,9 @@ end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # # in spec/support/ and its subdirectories.
-Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each do |f|
+  require f
+end
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
@@ -46,6 +53,6 @@ RSpec.configure do |config|
   config.before(:all) { reset_config }
 end
 
-def jruby? 
+def jruby?
   RUBY_PLATFORM == "java"
 end

--- a/spec/support/mock_helper.rb
+++ b/spec/support/mock_helper.rb
@@ -78,7 +78,7 @@ def stub_api_put(service_path, body, stub_fixture="success.json", opts={})
 end
 
 def log_stub(s)
-  SparkApi.logger.debug("Stubbed Request: #{s.inspect} \n\n")
+  SparkApi.logger.debug { "Stubbed Request: #{s.inspect} \n\n" }
   return s
 end
 

--- a/spec/unit/spark_api/request_spec.rb
+++ b/spec/unit/spark_api/request_spec.rb
@@ -193,16 +193,13 @@ describe SparkApi do
       end
 
       it "should give me BigDecimal results for large floating point numbers" do
-        MultiJson.default_adapter.should eq(:yajl) unless jruby?
+        MultiJson.default_adapter.should eq(:oj) unless jruby?
         result = subject.get('/listings/1000')[0]
-        result["StandardFields"]["BuildingAreaTotal"].should be_a(Float)
-        pending("our JSON parser does not support large decimal types.  Anyone feel like writing some c code?") do
-          result["StandardFields"]["BuildingAreaTotal"].should be_a(BigDecimal)
-          number = BigDecimal.new(result["StandardFields"]["BuildingAreaTotal"].to_s)
-          number.to_s.should eq(BigDecimal.new("0.000000000000000000000000001").to_s)
-          number = BigDecimal.new(result["StandardFields"]["ListPrice"].to_s)
-          number.to_s.should eq(BigDecimal.new("9999999999999999999999999.99").to_s)
-        end
+        result["StandardFields"]["BuildingAreaTotal"].should be_a(BigDecimal)
+        number = BigDecimal.new(result["StandardFields"]["BuildingAreaTotal"].to_s)
+        number.to_s.should eq(BigDecimal.new("0.000000000000000000000000001").to_s)
+        number = BigDecimal.new(result["StandardFields"]["ListPrice"].to_s)
+        number.to_s.should eq(BigDecimal.new("9999999999999999999999999.99").to_s)
       end
       
     end

--- a/spec/unit/spark_api_spec.rb
+++ b/spec/unit/spark_api_spec.rb
@@ -2,8 +2,8 @@ require './spec/spec_helper'
 
 describe SparkApi do
 
-  it "should use 'yajl-ruby' for parsing json" do
-    MultiJson.engine.should eq(MultiJson::Adapters::Yajl) unless jruby?
+  it "should use 'oj' for parsing json" do
+    MultiJson.engine.should eq(MultiJson::Adapters::Oj) unless jruby?
   end
 
   it "should load the version" do


### PR DESCRIPTION
Spark API allocate too much memory by generating big inspect data for debug messages.
Removed adding debug message if there is no debug level.

Replaced Yajl by Oj in order to reduce memory usage and json processing time.