### PR TITLE
FLEX-987: Handle missing unparsed first line address.

### DIFF
--- a/lib/spark_api/models/listing.rb
+++ b/lib/spark_api/models/listing.rb
@@ -129,7 +129,7 @@ module SparkApi
       end
 
       def street_address        
-        self.UnparsedFirstLineAddress.delete(DATA_MASK).strip().gsub(/\s{2,}/, ' ')
+        (self.UnparsedFirstLineAddress || '').delete(DATA_MASK).strip().gsub(/\s{2,}/, ' ')
       end
 
       def region_address

--- a/spec/unit/spark_api/models/listing_spec.rb
+++ b/spec/unit/spark_api/models/listing_spec.rb
@@ -87,13 +87,22 @@ describe Listing do
       @listing.should_not respond_to(:Videos)
     end
 
-    it "should return street address" do
-      @listing.street_address.should eq("100 Someone's St")
-    end
+    describe '.street_address' do
+      it 'should return the street address' do
+        @listing.street_address.should eq("100 Someone's St")
+      end
 
-    it "should remove masks from the street address" do
-      @listing.StandardFields["UnparsedFirstLineAddress"] = "********"
-      @listing.street_address.should eq("")
+      it 'should remove data masks' do
+        @listing.StandardFields["UnparsedFirstLineAddress"] = "********"
+        @listing.street_address.should eq("")
+      end
+
+      it 'should handle a missing unparsed first line address' do
+        [nil, '', ' '].each do |current|
+          @listing.StandardFields['UnparsedFirstLineAddress'] = current
+          @listing.street_address.should eq('')
+        end
+      end
     end
 
     it "should return the regional address" do


### PR DESCRIPTION
@baron-hines, @ryanhertz this should address the null (nil) pointer errors we're seeing in production.