### PR TITLE
added 'fields' method to QuickSearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp/*
 .buildpath
 .project
 *.swp
+dev.sh

--- a/lib/spark_api/models/search_template/quick_search.rb
+++ b/lib/spark_api/models/search_template/quick_search.rb
@@ -5,7 +5,12 @@ module SparkApi
       include Concerns::Savable,
               Concerns::Destroyable
 
-      self.element_name="searchtemplates/quicksearches"
+      self.element_name = "searchtemplates/quicksearches"
+
+      def fields(args = {})
+        arguments = {:_expand => "Fields"}.merge(args)
+        @fields ||= connection.get("/searchtemplates/quicksearches/#{self.Id}", arguments).first["Fields"]
+      end
 
     end
   end

--- a/spec/unit/spark_api/models/search_template/quick_search_spec.rb
+++ b/spec/unit/spark_api/models/search_template/quick_search_spec.rb
@@ -17,13 +17,25 @@ describe QuickSearch do
   end
 
   context '/searchtemplates/quicksearches/<id>' do
+
     let(:id) { "20121128132106172132000004" }
+
     it "gets an individual quick search" do
-      s = stub_api_get("/searchtemplates/quicksearches/#{id}", "search_templates/quick_searches/get.json")
-      quicksearch = QuickSearch.find(id)
+      s = stub_api_get("/searchtemplates/quicksearches/#{id}", "search_templates/quick_searches/get.json") 
+      quicksearch = QuickSearch.find(id) 
       quicksearch.should be_an(QuickSearch)
       s.should have_been_requested
     end
+
+    it "should have fields" do
+      stub_api_get("/searchtemplates/quicksearches/#{id}", "search_templates/quick_searches/get.json") 
+      quicksearch = QuickSearch.find(id) 
+      s = stub_api_get("/searchtemplates/quicksearches/#{quicksearch.Id}", "search_templates/quick_searches/get.json",
+        {:_expand => "Fields"}) 
+      quicksearch.fields.size.should eq(2)
+      s.should have_been_requested
+    end
+
   end
 
 end


### PR DESCRIPTION
This adds a `fields` method to the QuickSearch model that returns an array of the associated fields.
