### PR TITLE
added check argument in finders

### DIFF
--- a/lib/spark_api/models/finders.rb
+++ b/lib/spark_api/models/finders.rb
@@ -6,9 +6,9 @@ module SparkApi
 
       def find(*arguments)
         scope = arguments.slice!(0)
-        raise ArgumentError, "argument can't be nil" if scope.nil?
         options = arguments.slice!(0) || {}
         case scope
+          when nil    then raise ArgumentError, "Argument for find() can't be nil"
           when :all   then find_every(options)
           when :first then find_every(options).first
           when :last  then find_every(options).last

--- a/lib/spark_api/models/finders.rb
+++ b/lib/spark_api/models/finders.rb
@@ -6,6 +6,7 @@ module SparkApi
 
       def find(*arguments)
         scope = arguments.slice!(0)
+        raise ArgumentError, "argument can't be nil" if scope.nil?
         options = arguments.slice!(0) || {}
         case scope
           when :all   then find_every(options)

--- a/spec/unit/spark_api/models/finders_spec.rb
+++ b/spec/unit/spark_api/models/finders_spec.rb
@@ -32,4 +32,21 @@ describe Finders, "Finders model" do
     resource.Id.should eq(1)
   end
 
+  describe "find" do
+
+    it "should throw an error if no argument is passed" do
+      stub_api_get("/my_resource/", 'finders.json')
+      lambda {
+        MyResource.find()
+      }.should raise_error(ArgumentError)
+    end
+
+    it "should throw an error when the first argument is nil" do
+      stub_api_get("/my_resource/", 'finders.json', {:_limit => 1})
+      lambda {
+        MyResource.find(nil, {:_limit => 1})
+      }.should raise_error(ArgumentError)
+    end
+
+  end
 end


### PR DESCRIPTION
The `find` method will now throw an error without an argument.