### PR TITLE
Updated to faraday 0.9.0

### DIFF
--- a/lib/spark_api/authentication/oauth2_impl/faraday_middleware.rb
+++ b/lib/spark_api/authentication/oauth2_impl/faraday_middleware.rb
@@ -34,7 +34,7 @@ module SparkApi
         end
 
       end
-      Faraday.register_middleware :response, :oauth2_impl => FaradayMiddleware
+      Faraday::Response.register_middleware :oauth2_impl => FaradayMiddleware
       
       #==OAuth2 Faraday response middleware
       # HTTP Response after filter to package oauth2 responses and bubble up basic api errors.
@@ -62,7 +62,7 @@ module SparkApi
         end
   
       end
-      Faraday.register_middleware :response, :sparkbar_impl => SparkbarFaradayMiddleware
+      Faraday::Response.register_middleware :sparkbar_impl => SparkbarFaradayMiddleware
 
     end
   end

--- a/lib/spark_api/faraday_middleware.rb
+++ b/lib/spark_api/faraday_middleware.rb
@@ -80,6 +80,6 @@ module SparkApi
     end
     
   end
-  Faraday.register_middleware :response, :spark_api => FaradayMiddleware
+  Faraday::Response.register_middleware :spark_api => FaradayMiddleware
 
 end

--- a/spark_api.gemspec
+++ b/spark_api.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.default_executable = %q{spark_api}
   s.require_paths      = ["lib"]
   
-  s.add_dependency 'faraday', '~> 0.8.1'
+  s.add_dependency 'faraday', '~> 0.9.0'
   s.add_dependency 'multi_json', '~> 1.0'
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'builder', '>= 2.1.2', '< 4.0.0'

--- a/spec/unit/spark_api/configuration_spec.rb
+++ b/spec/unit/spark_api/configuration_spec.rb
@@ -39,7 +39,7 @@ describe SparkApi::Client, "Client config"  do
                                     :endpoint => "https://api.wade.dev.fbsdata.com",
                                     :ssl_verify => false)
       client.ssl_verify.should be_false
-      client.connection.ssl.should eq({:verify=>false})
+      client.connection.ssl.verify.should be_false
     end
 
     it "should allow restrict ssl certificates when verification is on" do
@@ -47,7 +47,7 @@ describe SparkApi::Client, "Client config"  do
                                     :endpoint => "https://api.wade.dev.fbsdata.com",
                                     :ssl_verify => true)
       client.ssl_verify.should be_true
-      client.connection.ssl.should eq({})
+      client.connection.ssl.should be_empty
     end
   end
 


### PR DESCRIPTION
Pretty simple change to make the client compatible with the new register_middleware format and fix a couple tests to validate against a new SSLOptions struct.