### PR TITLE
updated provided saved searches to allow newsfeeds

### DIFF
--- a/spec/fixtures/saved_searches/without_newsfeed.json
+++ b/spec/fixtures/saved_searches/without_newsfeed.json
@@ -1,0 +1,20 @@
+{
+    "D": {
+        "Success": true,
+        "Results": [
+            { 
+              "ResourceUri": "/v1/savedsearches/20100815220615294367000000",
+              "Id":  "20100815220615294367000000",
+              "Name": "Search name here",
+              "ContactIds": [
+                "20100815220615294367000000"
+              ],
+              "NewsFeedSubscriptionSummary": {
+                "ActiveSubscription": false
+              },
+              "NewsFeeds": []
+            }
+
+        ]
+    }
+}


### PR DESCRIPTION
When I originally set up saved search subscriptions, I though that provided searches were not eligible. It turns out they are eligible and this corrects that.