### PR TITLE
removed unnecessary and broken provided_search? method in SavedSearch

### DIFF
--- a/lib/spark_api/models/saved_search.rb
+++ b/lib/spark_api/models/saved_search.rb
@@ -24,9 +24,6 @@ module SparkApi
         Class.new(self).tap do |provided|
           provided.element_name = '/savedsearches'
           provided.prefix = '/provided'
-          def provided_search?
-            true
-          end
           SparkApi.logger.info("#{self.name}.path: #{provided.path}")
         end
       end
@@ -70,17 +67,13 @@ module SparkApi
 
       def listings(args = {})
         arguments = {:_filter => "SavedSearch Eq '#{self.Id}'"}
-        arguments.merge!(:RequestMode => 'permissive') if provided_search?
+        arguments.merge!(:RequestMode => 'permissive') if Provided?
         @listings ||= Listing.collect(connection.get("/listings", arguments.merge(args)))
       end
 
       def newsfeeds
         Newsfeed.collect(connection.get("#{self.class.path}/#{@attributes["Id"]}", 
           :_expand => "NewsFeeds").first["NewsFeeds"])
-      end
-
-      def provided_search?
-        false
       end
 
       def can_have_newsfeed?

--- a/spec/fixtures/saved_searches/get_provided.json
+++ b/spec/fixtures/saved_searches/get_provided.json
@@ -10,7 +10,7 @@
               "ContactIds": [
                 "20100815220615294367000000"
               ],
-              "Provided": false
+              "Provided": true
             },
             { 
               "ResourceUri": "/v1/savedsearches/20100615220615292711000000",

--- a/spec/unit/spark_api/models/saved_search_spec.rb
+++ b/spec/unit/spark_api/models/saved_search_spec.rb
@@ -111,7 +111,7 @@ describe SavedSearch do
       end
       
       it "should include the permissive parameter for provided searches" do
-        stub_api_get("/provided/savedsearches/#{id}", 'saved_searches/get.json')
+        stub_api_get("/provided/savedsearches/#{id}", 'saved_searches/get_provided.json')
         resource = subject.class.provided.find(id)
         expect(SparkApi.client).to receive(:get).with("/listings", 
           {:_filter => "SavedSearch Eq '#{id}'", :RequestMode => 'permissive'})
@@ -121,7 +121,6 @@ describe SavedSearch do
       it "should not include the permissive parameter for saved searches" do
         stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/get.json')
         resource = subject.class.find(id)
-        resource.stub(:provided_search?) { false }
         expect(SparkApi.client).to receive(:get).with("/listings", {:_filter => "SavedSearch Eq '#{id}'"})
         resource.listings
       end
@@ -191,7 +190,6 @@ describe SavedSearch do
     it "should return true with three filter parameters" do
       stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/get.json')
       resource = subject.class.find(id)
-      resource.stub(:provided_search?) { false }
       resource.stub(:has_active_newsfeed?) { false }
       resource.stub(:has_inactive_newsfeed?) { false }
       resource.can_have_newsfeed?.should == true
@@ -205,7 +203,6 @@ describe SavedSearch do
       stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/with_newsfeed.json',
         { "_expand" => "NewsFeedSubscriptionSummary" } )
       resource = subject.class.find(id)
-      resource.stub(:provided_search?) { false }
       resource.has_active_newsfeed?.should == true
     end
 
@@ -214,7 +211,6 @@ describe SavedSearch do
       stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/without_newsfeed.json',
         { "_expand" => "NewsFeedSubscriptionSummary" } )
       resource = subject.class.find(id)
-      resource.stub(:provided_search?) { false }
       resource.has_active_newsfeed?.should == false
     end
   end
@@ -225,7 +221,6 @@ describe SavedSearch do
       stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/with_inactive_newsfeed.json',
         { "_expand" => "NewsFeedSubscriptionSummary" } )
       resource = subject.class.find(id)
-      resource.stub(:provided_search?) { false }
       resource.has_inactive_newsfeed?.should == true
     end
 
@@ -234,7 +229,6 @@ describe SavedSearch do
       stub_api_get("/#{subject.class.element_name}/#{id}", 'saved_searches/without_newsfeed.json',
         { "_expand" => "NewsFeedSubscriptionSummary, NewsFeeds" } )
       resource = subject.class.find(id)
-      # resource.stub(:provided_search?) { false }
       resource.has_inactive_newsfeed?.should == false
     end
 


### PR DESCRIPTION
At some point, I added a provided_search? method to the Saved Search class. I just realized that Saved Search has a `Provided` attribute already, so it was completely unnecessary. Also, the method was broken because of how it was implemented inside the provided method.