### PR TITLE
fixed ListingCart#listings arguments

### DIFF
--- a/lib/spark_api/models/listing_cart.rb
+++ b/lib/spark_api/models/listing_cart.rb
@@ -34,8 +34,7 @@ module SparkApi
 
       def listings(args = {})
         return [] if attributes["ListingIds"].nil?
-        arguments = {:_filter => self.filter}.merge(args)
-        Listing.collect(connection.get("#{self.path}/#{self.Id}/listings", arguments))
+        Listing.collect(connection.get("#{self.path}/#{self.Id}/listings", args))
       end
 
       def add_listing(listing)

--- a/spec/unit/spark_api/models/listing_cart_spec.rb
+++ b/spec/unit/spark_api/models/listing_cart_spec.rb
@@ -136,8 +136,7 @@ describe ListingCart do
   describe "#listings" do 
     it "should return the listings in the cart" do 
       resource = subject.class.new Id: 5, ListingIds: ["1234"]
-      stub_api_get("/#{subject.class.element_name}/#{resource.Id}/listings", 'listings/multiple.json', 
-        :_filter => resource.filter)
+      stub_api_get("/#{subject.class.element_name}/#{resource.Id}/listings", 'listings/multiple.json')
       resource.listings.should be_a(Array)
       resource.listings.first.should be_a(Listing)
     end


### PR DESCRIPTION
This is probably my fault. We don't need to use the filter string when we are using `/listingcarts/:id/listings`.