### PR TITLE
RUBYAPI-37: fixed update_attributes

### DIFF
--- a/lib/spark_api/models/concerns/savable.rb
+++ b/lib/spark_api/models/concerns/savable.rb
@@ -28,8 +28,8 @@ module SparkApi
           true
         end
 
-        def update_attributes(attrs = {})
-          attrs.each{|k,v| public_send(:"#{k}=", v)}
+        def update_attributes(attrs = {}, options = {})
+          load(attrs, options)
           save!
         end
 

--- a/spec/unit/spark_api/models/concerns/savable_spec.rb
+++ b/spec/unit/spark_api/models/concerns/savable_spec.rb
@@ -74,4 +74,14 @@ describe Concerns::Savable, "Model" do
     s.should have_been_requested
   end
 
+  describe "update_attributes" do
+    it "loads the attributes" do
+      model = MyExampleModel.new
+      new_attributes = {Name: "My Name"}
+      expect(model).to receive(:load).with(new_attributes, {})
+      expect(model).to receive(:save!)
+      model.update_attributes(new_attributes)
+    end
+  end
+
 end


### PR DESCRIPTION
I added this `update_attributes` method a while ago before I found `load`, and I'm not sure if it ever worked correctly because it was missing `attribute_will_change!` stuff.