### PR TITLE
Json parse failure handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ v2.0.0
  - Drop support for ruby 1.9.3, require a minimum of ruby 2.2
  - Upgrade to Rspec 3
  - Upgrade all dependencies to current stable versions
+ - Catch MultiJson::ParseErrors and return SparkApi::InvalidJSON error instead
 
 v1.4.27
  - Added `dictionary_version` configuration option for RESO requests

--- a/lib/spark_api/errors.rb
+++ b/lib/spark_api/errors.rb
@@ -19,6 +19,7 @@ module SparkApi
   end
   
   # Errors built from API responses
+  class InvalidJSON < StandardError; end
   class InvalidResponse < StandardError; end
   class ClientError < StandardError
     attr_reader :code, :status, :details, :request_path, :request_id, :errors

--- a/lib/spark_api/faraday_middleware.rb
+++ b/lib/spark_api/faraday_middleware.rb
@@ -17,7 +17,12 @@ module SparkApi
     def on_complete(env)
       env[:body] = decompress_body(env)
 
-      body = MultiJson.decode(env[:body])
+      begin
+        body = MultiJson.decode(env[:body])
+      rescue MultiJson::ParseError => e
+        raise InvalidJSON, "Invalid JSON returned with HTTP #{env[:status]} for URI #{env[:url]}"
+      end
+
       SparkApi.logger.debug{ "Response Body: #{body.inspect}" }
       unless body.is_a?(Hash) && body.key?("D")
         raise InvalidResponse, "The server response could not be understood"

--- a/spec/unit/spark_api/faraday_middleware_spec.rb
+++ b/spec/unit/spark_api/faraday_middleware_spec.rb
@@ -76,7 +76,7 @@ describe SparkApi do
     it "should raised exception on invalid responses" do
       expect { @connection.get('/invalidjson')}.to raise_error(SparkApi::InvalidResponse)
       # This should be caught in the request code
-      expect { @connection.get('/garbage')}.to raise_error(MultiJson::DecodeError)
+      expect { @connection.get('/garbage')}.to raise_error(SparkApi::InvalidJSON)
     end
 
     it "should give me a session response" do


### PR DESCRIPTION
Trying to wrap up the few outstanding v2 changes and I need some design input on this one

I can't remember if we have an internal ticket tracking this and didn't find one when I looked briefly. 

questions:
 - is it worth having a SparkApi (gem) exception specifically for this, or should we close #139 as Won't Fix and keep the behavior how it's always been? The main benefit I see in adding a custom exception is we can have more actionable error messages in the logs, even if we don't catch the exceptions.
 - if we do move forward with this, should the error instance include [the request metadata](https://github.com/sparkapi/spark_api/blob/master/lib/spark_api/errors.rb#L31)? I could see it being nice to have this error outside the SparkApi::ClientError hierarchy so handlers that catch that generic exception continue to behave the same and don't start picking up this new exception as well, but I'm curious to hear other thoughts on that.